### PR TITLE
Update wordpress.md

### DIFF
--- a/network-services-pentesting/pentesting-web/wordpress.md
+++ b/network-services-pentesting/pentesting-web/wordpress.md
@@ -44,6 +44,7 @@ Default login paths to check: _**/wp-login.php, /wp-login/, /wp-admin/, /wp-admi
 * The `wp-content` folder is the main directory where plugins and themes are stored.
 * `wp-content/uploads/` Is the directory where any files uploaded to the platform are stored.
 * `wp-includes/` This is the directory where core files are stored, such as certificates, fonts, JavaScript files, and widgets.
+* `wp-sitemap.xml` In Wordpress versions 5.5 and greater, Worpress generates a sitemap XML file with all public posts and publicly queryable post types and taxonomies. 
 
 **Post exploitation**
 
@@ -141,7 +142,11 @@ You can also try to get information about the users by querying:
 ```
 curl http://blog.example.com/wp-json/wp/v2/users
 ```
-
+Another `/wp-json/` endpoint that can reveal some information about users is:
+```
+curl http://blog.example.com/wp-json/oembed/1.0/embed?url=POST-URL
+```
+Note that this endpoint only exposes users that have made a post. 
 **Only information about the users that has this feature enable will be provided**.
 
 Also note that **/wp-json/wp/v2/pages** could leak IP addresses.


### PR DESCRIPTION
Added some new knowledge to the Wordpress tricks page.

In versions 5.5 and greater, Wordpress now generates a sitemap file. This is now an important file to check since we can see all undocumented (unlinked) public URLs. 
https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/ 

Added a new wp-json endpoint for discovering users which is the oEmbed feature that Wordpress uses. It exposes the author's name and URL which contains the username for that user.